### PR TITLE
Add function dld_get_ga_tracking_id()

### DIFF
--- a/includes/simple-ga-tracking-output.php
+++ b/includes/simple-ga-tracking-output.php
@@ -37,8 +37,10 @@ function dld_add_ga_tracking() {
 			break;
 	}
 
+	$tracking_id = dld_get_ga_tracking_id();
+
 	if(
-		!empty( $options['ga_tracking_code'] ) // There is a tracking code
+		$tracking_id // There is a tracking code
 		&& !current_user_can( $user_option ) // The current user is less than the role defined
 	) {
 	?>
@@ -49,7 +51,7 @@ function dld_add_ga_tracking() {
 		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-		ga('create', '<?php echo esc_attr( $options["ga_tracking_code"] ); ?>', 'auto');
+		ga('create', '<?php echo esc_attr( $tracking_id ); ?>', 'auto');
 		ga('send', 'pageview');
 
 	</script>
@@ -59,3 +61,15 @@ function dld_add_ga_tracking() {
 	} // If there is a tracking id and user is allowed to be tracked
 
 }
+
+function dld_get_ga_tracking_id() {
+	$options = get_option("dld_ga_tracking_options");
+	if ( ! empty( $options ) ) {
+		$tracking_id = isset( $options['ga_tracking_code'] ) ? $options['ga_tracking_code'] : null;
+	} else {
+		$tracking_id = get_option("ga_tracking_code");
+	}
+	return $tracking_id;
+}
+
+


### PR DESCRIPTION
Add function dld_get_ga_tracking_id() for backwards compatibility when
retrieveing the GA ID.

This function should also make it easier to add a filter in the future.

See #8

Fixes #7