### PR TITLE
Allow more complex tracking via simple filters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ function sgat_custom_ga_tracking_id( $tracking_id ) {
   return $tracking_id;
 }
 ```
+
+If you want to modify the information used when creating the ga tracker, you can filter the arguments
+through the filter `sgat_tracker_create_fields`.
+
+Example Usage:
+```
+function my_sgat_tracker_create_fields( $fields ) {
+	$fields['siteSpeedSampleRate'] = 50;
+	return $fields;
+}
+add_action( 'sgat_tracker_create_fields', 'my_sgat_tracker_create_fields' );
+```
+
+If you want to add additional ga() calls after the main tracker output, you can hook onto the
+action `sgat_after_tracker`.
+
+Example Usage:
+```
+function my_sgat_after_tracker() {
+	echo "ga('send', 'event', 'MyCategory', 'MyAction', 'MyLabel', 50);";
+}
+add_action( 'sgat_after_tracker', 'my_sgat_after_tracker' );
+```
+
 Contributors
 -------------
 [@dustyndoyle](https://github.com/dustyndoyle),

--- a/includes/simple-ga-tracking-input.php
+++ b/includes/simple-ga-tracking-input.php
@@ -4,7 +4,7 @@
 add_action( 'admin_menu', 'sgat_add_option' );
 
 function sgat_add_option() {
-	add_options_page( 'Google Analtics', 'Google Analytics', 'manage_options', 'simple-google-analytics-tracking.php', 'sgat_admin_input' );
+	add_options_page( 'Google Analytics', 'Google Analytics', 'manage_options', 'simple-google-analytics-tracking.php', 'sgat_admin_input' );
 }
 
 function sgat_admin_input() {

--- a/includes/simple-ga-tracking-output.php
+++ b/includes/simple-ga-tracking-output.php
@@ -6,7 +6,11 @@ add_action( 'wp_head', 'sgat_add_tracking', 1 );
 function sgat_add_tracking() {
 
 	$tracking_id = apply_filters( 'sgat_tracking_id', get_option("sgat_tracking_code") );
-	
+	$create_options = apply_filters( 'sgat_tracker_create_fields', array(
+		'cookieDomain'  => 'auto',
+		'trackingId'    => $tracking_id,
+	) );
+
 	if(
 		!empty( $tracking_id ) // There is a tracking code
 		&& apply_filters( 'sgat_output_ga_code', sgat_allow_tracking() )
@@ -19,7 +23,7 @@ function sgat_add_tracking() {
 		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-		ga('create', '<?php echo esc_attr( $tracking_id ); ?>', 'auto');
+		ga('create', <?php echo json_encode( $create_options ); ?> );
 		ga('send', 'pageview');
 
 	</script>

--- a/includes/simple-ga-tracking-output.php
+++ b/includes/simple-ga-tracking-output.php
@@ -25,6 +25,7 @@ function sgat_add_tracking() {
 
 		ga('create', <?php echo json_encode( $create_options ); ?> );
 		ga('send', 'pageview');
+		<?php do_action( 'sgat_after_tracker' ); ?>
 
 	</script>
 	<!-- END: Simple Google Analytics Tracking Code -->


### PR DESCRIPTION
I love the simplicity of this plugin, however it would be great it the output could be tweaked by plugins / themes to allow them to do more complex things without having to move to manual output and/or a more complicated plugin. 

This PR:

- Fixes a typo in the admin page title
- Moves the setting of the cookieDomain, and trackingId into a JS fields object
- Makes that object filterable before use
- Adds an additional action after the tracker output
- Documents the new changes in the README

It'd be great to get these rolled into an official release.